### PR TITLE
Use String.isEmpty() instead of length() == 0 to check if a string is empty (Fix #15)

### DIFF
--- a/app/src/main/java/de/tadris/fitness/activity/ShowWorkoutActivity.java
+++ b/app/src/main/java/de/tadris/fitness/activity/ShowWorkoutActivity.java
@@ -154,7 +154,7 @@ public class ShowWorkoutActivity extends WorkoutActivity implements DialogUtils.
             }
             str += getString(R.string.comment) + ": " + workout.comment;
         }
-        if (str.length() == 0) {
+        if (str.isEmpty()) {
             str = getString(R.string.noComment);
         }
         commentView.setText(str);


### PR DESCRIPTION
**Technical Debt** 
 
The current implementation uses `str.length() == 0` to check if a string is empty. 
This approach is less direct and reduces code readability. 
Calling `String.isEmpty()` clearly communicates the intent and aligns with Java best practices.  

**Reference:**  

Java Documentation for `isEmpty()` -> (https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#isEmpty())

**Solution**

Replace the use of `str.length()` for comparison with the `isEmpty()` method

**Related Issue**

Issue Link - (https://github.com/SOEN6431Winter2025/FitoTrackW25/issues/15)