### PR TITLE
Fix: Disable cleartext traffic to resolve #53

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
+        android:usesCleartextTraffic="false"
         android:allowBackup="true"
         android:appCategory="productivity"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
This PR addresses issue #53 by setting `android:usesCleartextTraffic="false"` in the AndroidManifest.xml.  
It ensures that all network traffic is encrypted, preventing potential data leakage over unencrypted HTTP.

✅ Fixes #53
<img width="863" alt="Screenshot 2025-03-29 at 18 55 11" src="https://github.com/user-attachments/assets/26cde507-a58a-40f6-b0fc-bc036422e2ca" />
